### PR TITLE
v2.0.0-alpha.8

### DIFF
--- a/src/BeansClient.php
+++ b/src/BeansClient.php
@@ -446,10 +446,10 @@ class BeansClient
 
         $commandData = $this->dispatchCommand(new Command\PutCommand($payload, $priority, $delay, $ttr, $this->serializer ?: null));
 
-        if($commandData['status'] ?? null){
+        if ($commandData['status'] ?? null) {
             $commandData['status'] = mb_strtolower($commandData['status']);
 
-            if($commandData['status'] === 'inserted'){
+            if ($commandData['status'] === 'inserted') {
                 $commandData['status'] = Job::STATE_READY;
             }
         }
@@ -481,7 +481,7 @@ class BeansClient
      * @throws \xobotyi\beansclient\Exception\CommandException
      */
     public
-    function reserve(int $timeout = 0): ?Job {
+    function reserve(?int $timeout = null): ?Job {
         $result = $this->dispatchCommand(new Command\ReserveCommand($timeout, $this->serializer ?: null));
 
         if (!$result) {

--- a/src/Command/ReserveCommand.php
+++ b/src/Command/ReserveCommand.php
@@ -12,12 +12,12 @@ use xobotyi\beansclient\Response;
 class ReserveCommand extends Command implements CommandInterface
 {
     public
-    function __construct(int $timeout = 0, ?SerializerInterface $serializer = null) {
+    function __construct(?int $timeout = null, ?SerializerInterface $serializer = null) {
         if ($timeout < 0) {
             throw new CommandException("Timeout has to be >= 0");
         }
 
-        if ($timeout) {
+        if ($timeout !== null) {
             parent::__construct(CommandInterface::RESERVE_WITH_TIMEOUT, $serializer, [$timeout]);
         }
         else {

--- a/src/Job.php
+++ b/src/Job.php
@@ -275,6 +275,8 @@ class Job
             return $this;
         }
 
+        $this->client->delete($this->data['id']);
+
         $this->clearStatsFields();
         $this->data['state'] = self::STATE_DELETED;
 

--- a/tests/Command/ReserveCommandTest.php
+++ b/tests/Command/ReserveCommandTest.php
@@ -23,6 +23,11 @@ class ReserveCommandTest extends TestCase
 
         $this->assertEquals($command->getCommandName(), CommandInterface::RESERVE_WITH_TIMEOUT);
         $this->assertEquals($command->getArguments(), [3]);
+
+        $command = new ReserveCommand(0);
+
+        $this->assertEquals($command->getCommandName(), CommandInterface::RESERVE_WITH_TIMEOUT);
+        $this->assertEquals($command->getArguments(), [0]);
     }
 
     public


### PR DESCRIPTION
- Now 0 is passed as a `reserve-with-timeout` parameter, `null` now means regular `reserve` command and set by default;
- Fixed Job's `delete` method;

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/xobotyi/beansclient) and create your branch from `master`.
2. If you've fixed a bug or added code that should be tested, add tests!
3. Ensure the test suite passes.
